### PR TITLE
feat(fr2): add new subtitle

### DIFF
--- a/src/main/scala/com/github/polomarcus/html/ParserFR2.scala
+++ b/src/main/scala/com/github/polomarcus/html/ParserFR2.scala
@@ -73,7 +73,7 @@ object ParserFR2 {
         val publishedDate = doc >> text(".schedule span:nth-of-type(1)") // Diffusé le 08/01/2022
         val presenter = doc >> text(".presenter .by")
 
-        logger.debug(s"""
+        logger.info(s"""
             This is what i got for this day $url:
             number of news: ${news.length}
             date : $publishedDate
@@ -144,12 +144,17 @@ object ParserFR2 {
     (editor, editorDeputy.split(", ").toList)
   }
 
+  def parseSubtitle(doc: browser.DocumentType): String = {
+    (doc >?> text(".c-chapo")).getOrElse("")
+  }
+
   def parseDescriptionAuthors(
       url: String,
       defaultFrance2URL: String = "https://www.francetvinfo.fr") = {
     try {
       val doc: browser.DocumentType = browser.get(defaultFrance2URL + url)
       val descriptionOption = doc >?> text(".c-body")
+      val subtitle = parseSubtitle(doc)
       val description = descriptionOption match {
         case Some(descriptionValue) => descriptionValue
         case None => {
@@ -161,15 +166,16 @@ object ParserFR2 {
 
       val (editor, editorDeputy) = parseTeam(doc)
 
-      logger.debug(s"""
+      logger.info(s"""
       parseDescriptionAuthors from $url:
         $authors
         $editor
         $editorDeputy
+        $subtitle
         $description
       """)
 
-      (description, authors.getOrElse("").split(", ").toList, editor, editorDeputy)
+      (subtitle + description, authors.getOrElse("").split(", ").toList, editor, editorDeputy)
     } catch {
       case e: Exception => {
         logger.error(s"Error parsing this subject $defaultFrance2URL + $url " + e.toString)

--- a/src/test/scala/DateServiceTest.scala
+++ b/src/test/scala/DateServiceTest.scala
@@ -1,18 +1,28 @@
 import com.github.polomarcus.utils.DateService
+import com.github.polomarcus.utils.DateService.timezone
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.sql.Timestamp
+import java.text.SimpleDateFormat
 import java.time.{LocalDate, ZoneId}
-import java.util.Date
+import java.util.{Date, TimeZone}
 
 class DateServiceTest extends AnyFunSuite {
+  val timezone = TimeZone.getTimeZone("UTC+2")
+  val format = new SimpleDateFormat("dd/MM/yyyy")
+  format.setTimeZone(timezone)
+
   test("getTimestampFrance2") {
-    assert(DateService.getTimestampFrance2  ("Diffusé le 08/01/2022") == new Timestamp(new Date("01/08/2022").getTime))
+    assert(
+      DateService.getTimestampFrance2("Diffusé le 08/01/2022") ==
+        new Timestamp(format.parse("08/01/2022").getTime))
   }
 
   test("getTimestampTF1") {
-    assert(DateService.getTimestampTF1  ("Publié le 10 décembre 2020 à 20h08") == new Timestamp(new Date("12/10/2020").getTime))
-    assert(DateService.getTimestampTF1  ("Publié hier à 20h39").getTime >= 0)
-    assert(DateService.getTimestampTF1  ("Publié aujourd'hui à 20h39").getTime >= 0)
+    assert(
+      DateService.getTimestampTF1("Publié le 10 décembre 2020 à 20h08") ==
+        new Timestamp(format.parse("10/12/2020").getTime))
+    assert(DateService.getTimestampTF1("Publié hier à 20h39").getTime >= 0)
+    assert(DateService.getTimestampTF1("Publié aujourd'hui à 20h39").getTime >= 0)
   }
 }

--- a/src/test/scala/ParserFR2Test.scala
+++ b/src/test/scala/ParserFR2Test.scala
@@ -3,6 +3,7 @@ import com.github.polomarcus.html.Getter.logger
 import com.github.polomarcus.html.ParserFR2
 import com.github.polomarcus.html.ParserFR2.browser
 import com.github.polomarcus.model.News
+import com.github.polomarcus.utils.DateService
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.sql.Timestamp
@@ -16,12 +17,14 @@ class ParserFR2Test extends AnyFunSuite {
   test("parseFrance2Home") {
     val listNews = ParserFR2.parseFrance2Home(s"$localhost/home-tv-news-fr2.html", localhost)
 
+    val subtitle =
+      "La chute d'un pan de falaise sur des bateaux, qui naviguaient sur un lac touristique brésilien, a fait sept morts et trois disparus, samedi 8 janvier. Le bilan est provisoire, et les recherches se poursuivent."
     val description =
       "Au Brésil, un pan de falaise s'est détaché et a percuté des bateaux de touristes, samedi 8 janvier. Quelques minutes plus tôt, les touristes profitaient des décors sur le lac Furnas (Brésil). Soudain, un premier éboulement inquiète, suivi d'un autre. Les passagers d'un bateau tentent alors de donner l'alerte, en vain. Il est trop tard : un pan entier de la falaise s'effondre, et écrase les bateaux les plus proches. Le bilan est lourd : sept morts, et trois disparus. Les recherches ont repris Interrompues durant la nuit, les recherches se sont poursuivies dimanche. \"Nous pouvons voir maintenant des débris de bateau, qui ont été touchés dans l'accident\", a précisé l'un des pompiers. Deux heures avant la catastrophe, la protection civile avait recommandé d'éviter les cascades, en raison des fortes pluies. Une enquête devra déterminer si les compagnies de tourisme ont fait preuve de négligence."
     val news = News(
       "Brésil : effondrement meurtrier d'une falaise sur un groupe de touristes",
-      description,
-      new Timestamp(new Date("01/09/2022").getTime),
+      subtitle + description,
+      DateService.getTimestampFrance2("Diffusé le 09/01/2022"),
       1,
       "Laurent Delahousse",
       List("C.Verove", "O.Sauvayre"),
@@ -47,8 +50,8 @@ class ParserFR2Test extends AnyFunSuite {
     logger.info(s"listNews ${newsToHave}")
     val news = News(
       "Écoles : un nouveau protocole pour une rentrée marquée par l'incertitude",
-      "Mauvaise surprise pour les parents d'élèves d'une école de Poitiers (Vienne). Deux enseignantes sont absentes, positives au Covid-19, et l'une n'est pas remplacée. Une situation loin d'être isolée. Lundi 3 janvier à Paris, 13% des enseignants de primaire étaient absents. Les parents font donc l'école à la maison, tout en télétravaillant. Pour éviter cette situation, l'Éducation nationale promet d'embaucher des enseignants retraités et des vacataires. Guislaine David, cosecrétaire générale et porte-parole du SNUIPP-FSU, dénonce un manque de préparation. Protocole et gestes barrières Un établissement de région parisienne a décidé de maintenir toutes ses classes ouvertes, malgré une incertitude en fin de matinée. C'est un nouveau protocole pour les enseignants, mais aussi pour les élèves. Désormais, les enfants testés positifs resteront isolés 5 jours, puis feront un test. Pour revenir en classe, les cas contact devront présenter un test négatif, puis en refaire à J+2 et J+4. Un protocole qui s'accompagne d'une stricte application des gestes barrière.",
-      new Timestamp(new Date("01/03/2022").getTime),
+      "C'était un peu le saut dans l'inconnu, lundi 3 janvier, dans beaucoup d'écoles. Après deux semaines de vacances marquées par l'explosion de l'épidémie de Covid-19, on pouvait s'attendre à un absentéisme record, lundi 3 janvier, même si de nouvelles règles permettent de ne plus fermer les classes.Mauvaise surprise pour les parents d'élèves d'une école de Poitiers (Vienne). Deux enseignantes sont absentes, positives au Covid-19, et l'une n'est pas remplacée. Une situation loin d'être isolée. Lundi 3 janvier à Paris, 13% des enseignants de primaire étaient absents. Les parents font donc l'école à la maison, tout en télétravaillant. Pour éviter cette situation, l'Éducation nationale promet d'embaucher des enseignants retraités et des vacataires. Guislaine David, cosecrétaire générale et porte-parole du SNUIPP-FSU, dénonce un manque de préparation. Protocole et gestes barrières Un établissement de région parisienne a décidé de maintenir toutes ses classes ouvertes, malgré une incertitude en fin de matinée. C'est un nouveau protocole pour les enseignants, mais aussi pour les élèves. Désormais, les enfants testés positifs resteront isolés 5 jours, puis feront un test. Pour revenir en classe, les cas contact devront présenter un test négatif, puis en refaire à J+2 et J+4. Un protocole qui s'accompagne d'une stricte application des gestes barrière.",
+      DateService.getTimestampFrance2("Diffusé le 03/01/2022"),
       1,
       "Anne-Sophie Lapix",
       List("S. Soubane", "J. Ricco", "M. Mullot", "C.-M. Denis", "B. Vignais", "L. Lavieille"),
@@ -70,12 +73,20 @@ class ParserFR2Test extends AnyFunSuite {
     assert(List("Sébastien Renout", "Gilles Delbos") == editorDeputy)
   }
 
+  test("parseSubtitle") {
+    val doc = browser.get("http://localhost:8000/one-subject-tv-news-fr2.html")
+
+    val subtitle = ParserFR2.parseSubtitle(doc)
+    assert(
+      subtitle == "Bruxelles projette de leur apposer le label d’\"énergies vertes\", ce qui favoriserait les investissements dans ces énergies et permettrait d’atteindre la neutralité carbone.")
+  }
+
   test("parseDescriptionAuthors") {
     val (description, authors, editor, editorDeputy) =
       ParserFR2.parseDescriptionAuthors("/one-subject-tv-news-fr2.html", localhost)
 
     assert(
-      "Les centrales à gaz et les centrales nucléaires, bénéfiques au climat ? C’est une décision très controversée que s’apprête à adopter la Commission européenne. Elle propose en effet de classer le gaz et le nucléaire comme des énergies oeuvrant à la transition climatique, une position défendue par la France. \"On a besoin de toutes les énergies décarbonées pour lutter contre le réchauffement climatique\", avance Pascal Canfin, président de la commission Environnement au Parlement européen. Des pays anti-nucléaires vent debout contre la proposition Grâce à ce label, les investisseurs seraient encouragés à placer leur argent dans le gaz et le nucléaire. Mais certains pays anti-nucléaires, comme l’Allemagne, l’Autriche ou encore le Luxembourg, font entendre leur voix, et dénoncent une \"provocation\". \"On ne peut pas dire que le nucléaire est une énergie durable. N’allons pas investir de l’argent pour de nouvelles folies nucléaires\", annonce Damien Carème, eurodéputé. Pour que la mesure soit abandonnée, il faudrait que 20 pays s’y opposent." == description)
+      "Bruxelles projette de leur apposer le label d’\"énergies vertes\", ce qui favoriserait les investissements dans ces énergies et permettrait d’atteindre la neutralité carbone.Les centrales à gaz et les centrales nucléaires, bénéfiques au climat ? C’est une décision très controversée que s’apprête à adopter la Commission européenne. Elle propose en effet de classer le gaz et le nucléaire comme des énergies oeuvrant à la transition climatique, une position défendue par la France. \"On a besoin de toutes les énergies décarbonées pour lutter contre le réchauffement climatique\", avance Pascal Canfin, président de la commission Environnement au Parlement européen. Des pays anti-nucléaires vent debout contre la proposition Grâce à ce label, les investisseurs seraient encouragés à placer leur argent dans le gaz et le nucléaire. Mais certains pays anti-nucléaires, comme l’Allemagne, l’Autriche ou encore le Luxembourg, font entendre leur voix, et dénoncent une \"provocation\". \"On ne peut pas dire que le nucléaire est une énergie durable. N’allons pas investir de l’argent pour de nouvelles folies nucléaires\", annonce Damien Carème, eurodéputé. Pour que la mesure soit abandonnée, il faudrait que 20 pays s’y opposent." == description)
     assert(
       List("J.Gasparutto", "C.Vanpée", "H.Huet", "F.Ducobu", "S.Giaume", "S.Carter") == authors)
     assert("Elsa Pallot" == editor)

--- a/src/test/scala/ParserTF1Test.scala
+++ b/src/test/scala/ParserTF1Test.scala
@@ -1,6 +1,7 @@
 import com.github.polomarcus.html.Getter.logger
 import com.github.polomarcus.html.ParserTF1
 import com.github.polomarcus.model.News
+import com.github.polomarcus.utils.DateService
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.sql.Timestamp
@@ -11,10 +12,12 @@ class ParserTF1Test extends AnyFunSuite {
   test("parseTF1HomeHelper") {
     val listNews = ParserTF1.parseTF1HomeHelper(s"$localhost/home-tv-news-tf1.html", localhost)
 
-    val description = "L'essentiel Certes, ils sont en général moins chers, mais ils ont la réputation d’être de moins bonne qualité que les articles de grandes marques. Un produit sur trois, vendus en France, est une marque distributeur. Que valent-ils vraiment ?  ans les rayons, elles sont partout. U, Carrefour, Auchan, Franprix, ce sont les marques des distributeurs. Leur vente ne cesse d’augmenter. Ces produits coûtent en moyenne 30% de moins que les marques nationales. Des petits prix qui séduisent les consommateurs. Produits d’hygiène, pâtes, surgelés, pour fidéliser leurs clients, les distributeurs créent sans cesse de nouveaux produits.  Un produit sur trois vendus en France est une marque de distributeur. Que valent-ils vraiment ? Sont-ils moins bons ou meilleurs que les grandes marques ? Première surprise, ils sont souvent fabriqués dans les mêmes usines. Comme ici, des salades sont mises en sachet pour une marque de distributeur. À droite, pour une marque nationale.  Mais il y a quand même quelques différences. En clair, les grandes marques privilégient les parties les plus nobles. C’est ce qui explique l'écart de prix. Mais ce n’est pas la seule raison. Avec les marques nationales, vous payez bien plus que le produit. Et en regardant de près les étiquettes, on apprend que les qualités nutritionnelles sont souvent identiques.  T F1 | Reportage L. Deschateaux, M. Derre, V. Daran"
-    val news = News("JT20H - Jardinier, cadre, formateur … dans cette entreprise, les salariés sont tous handicapés",
+    val description =
+      "L'essentiel Certes, ils sont en général moins chers, mais ils ont la réputation d’être de moins bonne qualité que les articles de grandes marques. Un produit sur trois, vendus en France, est une marque distributeur. Que valent-ils vraiment ?  ans les rayons, elles sont partout. U, Carrefour, Auchan, Franprix, ce sont les marques des distributeurs. Leur vente ne cesse d’augmenter. Ces produits coûtent en moyenne 30% de moins que les marques nationales. Des petits prix qui séduisent les consommateurs. Produits d’hygiène, pâtes, surgelés, pour fidéliser leurs clients, les distributeurs créent sans cesse de nouveaux produits.  Un produit sur trois vendus en France est une marque de distributeur. Que valent-ils vraiment ? Sont-ils moins bons ou meilleurs que les grandes marques ? Première surprise, ils sont souvent fabriqués dans les mêmes usines. Comme ici, des salades sont mises en sachet pour une marque de distributeur. À droite, pour une marque nationale.  Mais il y a quand même quelques différences. En clair, les grandes marques privilégient les parties les plus nobles. C’est ce qui explique l'écart de prix. Mais ce n’est pas la seule raison. Avec les marques nationales, vous payez bien plus que le produit. Et en regardant de près les étiquettes, on apprend que les qualités nutritionnelles sont souvent identiques.  T F1 | Reportage L. Deschateaux, M. Derre, V. Daran"
+    val news = News(
+      "JT20H - Jardinier, cadre, formateur … dans cette entreprise, les salariés sont tous handicapés",
       description,
-      new Timestamp(new Date("11/16/2016").getTime),
+      DateService.getTimestampTF1("Diffusé le 16/11/2016 à 20h08"),
       0,
       "",
       List("L. Deschateaux", "M. Derre", "V. Daran"),
@@ -30,16 +33,23 @@ class ParserTF1Test extends AnyFunSuite {
   }
 
   test("parseDescriptionAuthors") {
-    val (description, authors, editor, editorDeputy) = ParserTF1.parseDescriptionAuthors("/one-subject-tv-news-tf1.html", localhost)
+    val (description, authors, editor, editorDeputy) =
+      ParserTF1.parseDescriptionAuthors("/one-subject-tv-news-tf1.html", localhost)
 
-    assert("L'essentiel Certes, ils sont en général moins chers, mais ils ont la réputation d’être de " == description.take(90))
+    assert(
+      "L'essentiel Certes, ils sont en général moins chers, mais ils ont la réputation d’être de " == description
+        .take(90))
     assert(List("L. Deschateaux", "M. Derre", "V. Daran") == authors)
     assert("" == editor)
     assert(List("") == editorDeputy)
   }
 
   test("parseAuthors") {
-    assert(ParserTF1.parseAuthors("T F1 | Reportage T. Jarrion, F. Couturon, F. Petit") == List("T. Jarrion", "F. Couturon", "F. Petit"))
+    assert(
+      ParserTF1.parseAuthors("T F1 | Reportage T. Jarrion, F. Couturon, F. Petit") == List(
+        "T. Jarrion",
+        "F. Couturon",
+        "F. Petit"))
     assert(ParserTF1.parseAuthors("T F1 | Reportage T. Jarrion") == List("T. Jarrion"))
     assert(ParserTF1.parseAuthors("F. Petit") == List(""))
   }


### PR DESCRIPTION
Pour France 2, prendre en compte le sous titre des reportages `(".c-chapo"),` car cette partie peut prendre contenir les mots clés sur les changements climatiques



https://www.francetvinfo.fr/monde/environnement/centrales-a-charbon-elles-tournent-encore-malgre-une-fermeture-definitive-prevue-finmars_5022271.html