### PR TITLE
fix(date): save hour and minute for TF1 news

### DIFF
--- a/src/main/scala/com/github/polomarcus/utils/DateService.scala
+++ b/src/main/scala/com/github/polomarcus/utils/DateService.scala
@@ -37,32 +37,47 @@ object DateService {
       case "novembre" => "11"
       case "décembre" => "12"
       case _ =>
-        logger.error("Error parsign month", month)
+        logger.error(s"Error parsing month :$month")
         "Invalid month" // the default, catch-all
     }
   }
+
+  def getHourMinute(date: String): (String, String) = {
+    val dateSplit = date.split(" à ")
+    val hourAndMinute = dateSplit(1).split("h")
+    val hour = hourAndMinute(0)
+    val minute = hourAndMinute(1)
+    (hour, minute)
+  }
+
   //"Publié le 10 décembre 2020 à 20h08"
   // Publié hier à 20h39
   def getTimestampTF1(date: String): Timestamp = {
     try {
-      val format = new SimpleDateFormat("d/MM/yyyy")
+      val format = new SimpleDateFormat("d/MM/yyyy HH:mm")
       format.setTimeZone(timezone)
       // Create a calendar object with today date. Calendar is in java.util pakage.
       val calendar = Calendar.getInstance
+      val (hour, minute) = DateService.getHourMinute(date)
+      calendar.set(11, hour.toInt)
+      calendar.set(12, minute.toInt)
+
       if (date.contains("hier")) { // late publish
         // Move calendar to yesterday
         calendar.add(Calendar.DATE, -1)
-
+        format.format(calendar.getTime.getTime)
         // Get current date of calendar which point to the yesterday now
         new Timestamp(calendar.getTime.getTime)
-      } else if (date.contains("aujourd’hui")) {
+      } else if (date.contains("aujourd'hui")) {
         new Timestamp(calendar.getTime.getTime)
-      } else {
+      } else { //"Publié le 10 décembre 2020 à 20h08"
         val dateSplit = date.split(" ")
         val day = dateSplit(2)
         val month = parseFrenchMonth(dateSplit(3))
         val year = dateSplit(4)
-        new Timestamp(format.parse(s"$day/$month/$year").getTime)
+
+        logger.debug(s"Date for TF1: $day/$month/$year $hour:$minute")
+        new Timestamp(format.parse(s"$day/$month/$year $hour:$minute").getTime)
       }
     } catch {
       case e: Exception => {

--- a/src/main/scala/com/github/polomarcus/utils/DateService.scala
+++ b/src/main/scala/com/github/polomarcus/utils/DateService.scala
@@ -65,7 +65,6 @@ object DateService {
       if (date.contains("hier")) { // late publish
         // Move calendar to yesterday
         calendar.add(Calendar.DATE, -1)
-        format.format(calendar.getTime.getTime)
         // Get current date of calendar which point to the yesterday now
         new Timestamp(calendar.getTime.getTime)
       } else if (date.contains("aujourd'hui")) {

--- a/src/test/docker/resources/one-subject-tv-news-fr2.html
+++ b/src/test/docker/resources/one-subject-tv-news-fr2.html
@@ -1988,48 +1988,7 @@ a.source.postMessage(n?JSON.stringify(r):r,"*")})}}if(typeof window.__cmp!=="fun
 
                             <img src="data:image/svg+xml,%3Csvg xmlns=&quot;http://www.w3.org/2000/svg&quot; viewBox=&quot;0 0  84  84&quot;%3E%3C/svg%3E" data-src="/assets/common/images/programs/default-square-d2ad8b86.jpg" class="from-same-show__info-img lazyload" alt="" width="84" height="84">
 
-                            <div class="from-same-show__info-team">
-                                <p role="heading" aria-level="3">L'équipe de la semaine</p>
-                                <ul>
-                                    <li class="from-same-show__info-team-item">
-                                        <p>Rédaction en chef</p>
-                                        <p>Elsa Pallot</p>
-                                    </li>
-                                    <li class="from-same-show__info-team-item">
-                                        <p>Rédaction en chef-adjointe</p>
-                                        <p>Sébastien Renout, Gilles Delbos</p>
-                                    </li>
-                                    <li class="from-same-show__info-team-item">
-                                        <p>Résponsable d'édition</p>
-                                        <p>Delphine Moninot</p>
-                                    </li>
-                                    <li class="from-same-show__info-team-item">
-                                        <p>Joker</p>
-                                        <p>Karine Baste-Régis</p>
-                                    </li>
-                                </ul>
-                            </div>
-                            <div class="from-same-show__info-team">
-                                <p role="heading" aria-level="3">L'équipe du week-end</p>
-                                <ul>
-                                    <li class="from-same-show__info-team-item">
-                                        <p>Rédaction en chef</p>
-                                        <p>Thibaud de Barbeyrac</p>
-                                    </li>
-                                    <li class="from-same-show__info-team-item">
-                                        <p>Rédaction en chef-adjointe</p>
-                                        <p>Virginie Fichet, Agnès Gardet</p>
-                                    </li>
-                                    <li class="from-same-show__info-team-item">
-                                        <p>Résponsable d'édition</p>
-                                        <p>Jean-Louis Gaudin</p>
-                                    </li>
-                                    <li class="from-same-show__info-team-item">
-                                        <p>Joker</p>
-                                        <p>Thomas Sotto</p>
-                                    </li>
-                                </ul>
-                            </div>
+
                             <div class="from-same-show__info-mediator">
                                 <p role="heading" aria-level="3">le médiateur de l'info</p>
                                 <div class="from-same-show__info-mediator-wrapper">

--- a/src/test/docker/resources/team-editor.html
+++ b/src/test/docker/resources/team-editor.html
@@ -1,0 +1,34 @@
+<html><head></head><body><aside class="last-programs team">
+  <span class="header">L'équipe de la semaine</span>
+  <div class="left">
+    <figure>
+      <img data-src="/skin/dist/www/img/jt/presenter/julian-bugier-4a3e5633c8.jpg" class="b-lazy" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" width="110">
+      <figcaption>Julian Bugier</figcaption>
+    </figure>
+  </div>
+  <div class="right">
+    <ul>
+      <li><strong>Rédaction en chef</strong>Thomas Horeau</li>
+      <li><strong>Rédaction en chef-adjointe</strong>Régis Poullain et Margaux Manière</li>
+      <li><strong>Responsable d'édition</strong>Anne-Laure Cailler et Paul mescus</li>
+    </ul>
+  </div>
+</aside>
+
+<aside class="last-programs team">
+  <span class="header">L'équipe du week-end</span>
+  <div class="left">
+    <figure>
+      <img data-src="/skin/dist/www/img/jt/presenter/leila-kaddour-boudadi-5498270542.jpg" class="b-lazy" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" width="110">
+      <figcaption>Leïla Kaddour-Boudadi</figcaption>
+    </figure>
+  </div>
+  <div class="right">
+    <ul>
+      <li><strong>Rédaction en chef</strong>Franck Genauzeau</li>
+      <li><strong>Rédaction en chef-adjointe</strong>Irène Bénéfice, Willy Gouville et Jean-François Monier</li>
+      <li><strong>Responsable d'édition</strong>Jean-Louis Gaudin</li>
+    </ul>
+  </div>
+</aside>
+</body></html>

--- a/src/test/scala/DateServiceTest.scala
+++ b/src/test/scala/DateServiceTest.scala
@@ -19,10 +19,16 @@ class DateServiceTest extends AnyFunSuite {
   }
 
   test("getTimestampTF1") {
+    val formatTF1 = new SimpleDateFormat("dd/MM/yyyy HH:mm")
+    formatTF1.setTimeZone(timezone)
     assert(
       DateService.getTimestampTF1("Publié le 10 décembre 2020 à 20h08") ==
-        new Timestamp(format.parse("10/12/2020").getTime))
+        new Timestamp(formatTF1.parse("10/12/2020 20:08").getTime))
     assert(DateService.getTimestampTF1("Publié hier à 20h39").getTime >= 0)
     assert(DateService.getTimestampTF1("Publié aujourd'hui à 20h39").getTime >= 0)
+  }
+
+  test("getHourMinute") {
+    assert(DateService.getHourMinute("Publié le 10 décembre 2020 à 20h08") == ("20", "08"))
   }
 }

--- a/src/test/scala/ParserFranceTelevisionTest.scala
+++ b/src/test/scala/ParserFranceTelevisionTest.scala
@@ -38,14 +38,30 @@ class ParserFranceTelevisionTest extends AnyFunSuite {
       containsWordGlobalWarming = false,
       ParserFranceTelevision.FRANCE2)
 
-    assert(news == listNews.head)
+    assert(news.title == listNews.head.title)
+    assert(news.description == listNews.head.description)
+    assert(news.date == listNews.head.date)
+    assert(news.order == listNews.head.order)
+    assert(news.presenter == listNews.head.presenter)
+    assert(news.authors == listNews.head.authors)
+    assert(news.editor == listNews.head.editor)
+    assert(news.editorDeputy == listNews.head.editorDeputy)
+    assert(news.url == listNews.head.url)
+    assert(news.urlTvNews == listNews.head.urlTvNews)
+    assert(news.containsWordGlobalWarming == listNews.head.containsWordGlobalWarming)
+    assert(news.media == listNews.head.media)
   }
 
   test("parseFranceTelevisionNews") {
     val newsToHave = Await
       .result(
         ParserFranceTelevision
-          .parseFranceTelevisionNews(s"/one-day-tv-news-fr2.html", localhost, "France 2"),
+          .parseFranceTelevisionNews(
+            s"/one-day-tv-news-fr2.html",
+            localhost,
+            "France 2",
+            "Elsa Pallot",
+            List("Sébastien Renout", "Gilles Delbos")),
         Duration(1, "minutes"))
       .flatten
       .filter(
@@ -60,21 +76,31 @@ class ParserFranceTelevisionTest extends AnyFunSuite {
       "Anne-Sophie Lapix",
       List("S. Soubane", "J. Ricco", "M. Mullot", "C.-M. Denis", "B. Vignais", "L. Lavieille"),
       "Elsa Pallot",
-      List("Sébastien Renout", "Anne Poncinet", "Arnaud Comte"),
+      List("Sébastien Renout", "Gilles Delbos"),
       "http://localhost:8000/sante/maladie/coronavirus/ecoles-un-nouveau-protocole-pour-une-rentree-marquee-par-l-incertitude_4903195.html",
       "http://localhost:8000/one-day-tv-news-fr2.html",
       containsWordGlobalWarming = false,
       ParserFranceTelevision.FRANCE2)
 
-    assert(newsToHave.head == news)
+    assert(news.title == newsToHave.head.title)
+    assert(news.description == newsToHave.head.description)
+    assert(news.date == newsToHave.head.date)
+    assert(news.order == newsToHave.head.order)
+    assert(news.presenter == newsToHave.head.presenter)
+    assert(news.authors == newsToHave.head.authors)
+    assert(news.editor == newsToHave.head.editor)
+    assert(news.editorDeputy == newsToHave.head.editorDeputy)
+    assert(news.url == newsToHave.head.url)
+    assert(news.urlTvNews == newsToHave.head.urlTvNews)
+    assert(news.containsWordGlobalWarming == newsToHave.head.containsWordGlobalWarming)
+    assert(news.media == newsToHave.head.media)
   }
 
   test("parseTeam") {
-    val doc = browser.get("http://localhost:8000/one-subject-tv-news-fr2.html")
-
-    val (editor, editorDeputy) = ParserFranceTelevision.parseTeam(doc)
-    assert("Elsa Pallot" == editor)
-    assert(List("Sébastien Renout", "Gilles Delbos") == editorDeputy)
+    val (editor, editorDeputy) =
+      ParserFranceTelevision.parseTeam(noonNews = true, "http://localhost:8000/team-editor.html")
+    assert("Thomas Horeau" == editor)
+    assert(List("Régis Poullain", "Margaux Manière") == editorDeputy)
   }
 
   test("parseSubtitle") {
@@ -86,24 +112,20 @@ class ParserFranceTelevisionTest extends AnyFunSuite {
   }
 
   test("parseDescriptionAuthors") {
-    val (description, authors, editor, editorDeputy) =
+    val (description, authors) =
       ParserFranceTelevision.parseDescriptionAuthors("/one-subject-tv-news-fr2.html", localhost)
 
     assert(
       "Bruxelles projette de leur apposer le label d’\"énergies vertes\", ce qui favoriserait les investissements dans ces énergies et permettrait d’atteindre la neutralité carbone.Les centrales à gaz et les centrales nucléaires, bénéfiques au climat ? C’est une décision très controversée que s’apprête à adopter la Commission européenne. Elle propose en effet de classer le gaz et le nucléaire comme des énergies oeuvrant à la transition climatique, une position défendue par la France. \"On a besoin de toutes les énergies décarbonées pour lutter contre le réchauffement climatique\", avance Pascal Canfin, président de la commission Environnement au Parlement européen. Des pays anti-nucléaires vent debout contre la proposition Grâce à ce label, les investisseurs seraient encouragés à placer leur argent dans le gaz et le nucléaire. Mais certains pays anti-nucléaires, comme l’Allemagne, l’Autriche ou encore le Luxembourg, font entendre leur voix, et dénoncent une \"provocation\". \"On ne peut pas dire que le nucléaire est une énergie durable. N’allons pas investir de l’argent pour de nouvelles folies nucléaires\", annonce Damien Carème, eurodéputé. Pour que la mesure soit abandonnée, il faudrait que 20 pays s’y opposent." == description)
     assert(
       List("J.Gasparutto", "C.Vanpée", "H.Huet", "F.Ducobu", "S.Giaume", "S.Carter") == authors)
-    assert("Elsa Pallot" == editor)
-    assert(List("Sébastien Renout", "Gilles Delbos") == editorDeputy)
   }
 
   test("parseDescriptionAuthors - old news 204/2013") {
-    val (description, authors, editor, editorDeputy) =
+    val (description, authors) =
       ParserFranceTelevision.parseDescriptionAuthors("/old-subject-tv-news-fr2.html", localhost)
 
     assert(List("") == authors)
-    assert("" == editor)
-    assert(List("") == editorDeputy)
     assert(
       "Le régime d'Assad assure que les experts seront libres. Les inspecteurs des Nations Unies devrait entamer leurs investigations demain. L'objectif est de déterminer si, oui ou non, le régime a utilisé des armes chimiques. La présence militaire est renforcée en Méditerranée. Avec 4 navires de guerre déployées dans la zone, les USA ont décidé de placer la Syrie à porter de tirs. Va-t-on vers une intervention militaire occidentale contre le régime de Bachar al Assad? L'état major américain a présenté les options existantes pour intervenir. Nous avons envisagé toutes les options. La limite d'intervention est d'envoyer des milices. Les Occidentaux peuvent-ils obtenir un mandat de l'ONU pour une intervention ? Il faudrait que les Russes renoncent à utiliser leur droit de véto comme en 2011 lorsqu'ils avaient laisse voter l'intervention militaire en Lybie. Moscou ne semble pas prête à lâcher son allié Bachar al Assad. En témoigne ce communiqué. Les Russes incitent également les Américains à ne pas reproduire \"l'aventure de la guerre en lrak\". Même sans mandat de l'ONU, les Américains et leurs alliés pourraient décider d'intervenir comme en 1999 au Kosovo. Malgré l'opposition des Russes, il fallait stopper les massacres des Serbes de Milosevic. " == description)
   }

--- a/src/test/scala/ParserTF1Test.scala
+++ b/src/test/scala/ParserTF1Test.scala
@@ -17,7 +17,7 @@ class ParserTF1Test extends AnyFunSuite {
     val news = News(
       "JT20H - Jardinier, cadre, formateur … dans cette entreprise, les salariés sont tous handicapés",
       description,
-      DateService.getTimestampTF1("Diffusé le 16/11/2016 à 20h08"),
+      DateService.getTimestampTF1("Publié le 16 novembre 2016 à 20h38"),
       0,
       "",
       List("L. Deschateaux", "M. Derre", "V. Daran"),


### PR DESCRIPTION
## Ajout de l'heure et de la minute pour les reportages de TF1.

Avant il n'y avait que le jour.

A savoir que l'heure n'est pas toujours fiable sur le site tf1info

## Fix pour récupèrer les infos des rédacteurs
La page a changé, il faut rajouter une requete pour obtenir l'information