### PR TITLE
fix: percent-encode braces and quotes in France 2 ESI URL

### DIFF
--- a/src/main/scala/com/github/polomarcus/html/ParserFranceTelevision.scala
+++ b/src/main/scala/com/github/polomarcus/html/ParserFranceTelevision.scala
@@ -151,8 +151,14 @@ object ParserFranceTelevision {
       esiUrlOpt match {
         case Some(esiPath) if esiPath.nonEmpty =>
           val esiUrl = if (esiPath.startsWith("http")) esiPath else defaultUrl + esiPath
-          logger.debug(s"Fetching news list from ESI block: $esiUrl")
-          val esiDoc = browser.get(esiUrl)
+          // The ESI path embeds a JSON literal like /index/{"contentId":...}.html.
+          // java.net.URL rejects the unescaped braces/quotes, so percent-encode them.
+          val safeEsiUrl = esiUrl
+            .replace("{", "%7B")
+            .replace("}", "%7D")
+            .replace("\"", "%22")
+          logger.debug(s"Fetching news list from ESI block: $safeEsiUrl")
+          val esiDoc = browser.get(safeEsiUrl)
           esiDoc >> elementList(htmlSelectorAllNewsFromOneDay)
         case _ =>
           logger.warn("No news list found on day page and no SameShowESI data-esi-url attribute")


### PR DESCRIPTION
## Context

Follow-up to #41. After the merge, the scheduled \`save-data.yml\` workflow run (https://github.com/polomarcus/television-news-analyser/actions/runs/27228105808) still failed for France 2 with:

\`\`\`
java.net.MalformedURLException: Illegal character in path at index 66:
  https://www.francetvinfo.fr/esi-block/contents::SameShowESI/index/{"contentId":8015657,"darkMode":true,"extended":true}.html
\`\`\`

France TV's ESI URL embeds a literal JSON object in the path. \`java.net.URL\` (used under the hood by scala-scraper/jsoup) rejects the unescaped \`{\`, \`}\`, and \`"\` characters before any HTTP request is made.

The unit test passed because the mock fixture's \`data-esi-url\` uses a query string (\`?block=SameShowESI\`) without those characters.

## Summary
- Percent-encode \`{\`, \`}\`, and \`"\` before calling \`browser.get(...)\` on the ESI URL.

## Test plan
- [x] \`sbt "testOnly ParserFranceTelevisionTest"\` — 8/8 pass locally
- [ ] Re-trigger \`Get news from websites\` workflow on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)